### PR TITLE
fix: prevent gaming via DecreaseLiquidity events

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "swap-subnet"
-version = "7.0.0"
+version = "7.0.1"
 description = "Bringing liquidity to Bittensor"
 readme = "README.md"
 authors = [

--- a/swap/__init__.py
+++ b/swap/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
-__version__ = "7.0.0"
+__version__ = "7.0.1"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 

--- a/swap/base/neuron.py
+++ b/swap/base/neuron.py
@@ -54,7 +54,7 @@ class BaseNeuron(ABC):
     subtensor: bt.AsyncSubtensor
     wallet: bt.wallet
     metagraph: AsyncMetagraph
-    spec_version: int = 7000
+    spec_version: int = 7001
 
     @property
     async def block(self) -> int:

--- a/uv.lock
+++ b/uv.lock
@@ -1524,7 +1524,7 @@ wheels = [
 
 [[package]]
 name = "swap-subnet"
-version = "7.0.0"
+version = "7.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-types" },


### PR DESCRIPTION
Both burns and DecreaseLiquidity amounts should be subtracted from uncollected fees separately, not adjusted against each other. The previous logic allowed miners to game the system by creating positions and immediately decreasing liquidity, which would cancel out the burn and count as fees.

- remove calculate_adjusted_burn_amounts() function
- subtract burns and DecreaseLiquidity amounts independently
- prevent miners from gaming fees by liquidity manipulation